### PR TITLE
Enforce SQLAlchemy 1.3.24 to keep support for ResultProxy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Cython
-SQLAlchemy
+SQLAlchemy==1.3.24
 alembic
 PyYAML
 Flask


### PR DESCRIPTION
Assuming a Python 3.6 environment, SQLAlchemy>=1.4.0 does not have support for importing ResultProxy from sqlalchemy.engine.result. This causes errors any time you try to use base.py/read.py and perform database actions. The simple fix is to ensure SQLAlchemy is kept to at least 1.3.24 which matches the time period the code was written in anyways.